### PR TITLE
Fixing path separator bug in Maven pom

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 14/12/2011
 
 Added support of non-local returns for blocks with ^ in them.
+Fixing path separator bug in Maven pom that affects Windows hosts.
 
 11/12/2011
 

--- a/pom.xml
+++ b/pom.xml
@@ -165,9 +165,9 @@
               <mainClass>st.redline.Stic</mainClass>
               <arguments>
                 <argument>-r</argument>
-                <argument>${project.basedir}/src/main/smalltalk</argument>
+                <argument>${project.basedir}${path.separator}src${path.separator}main${path.separator}smalltalk</argument>
                 <argument>-s</argument>
-                <argument>${project.basedir}/src/test/smalltalk</argument>
+                <argument>${project.basedir}${path.separator}src${path.separator}test${path.separator}smalltalk</argument>
                 <argument>st.redline.Tests</argument>
               </arguments>
             </configuration>


### PR DESCRIPTION
Had / hardcoded in the pom, should have used ${path.separator}
