### PR TITLE
some Object error handling additions

### DIFF
--- a/src/main/smalltalk/st/redline/Object.st
+++ b/src/main/smalltalk/st/redline/Object.st
@@ -140,8 +140,35 @@ ProtoObject < #Object
   "NOTE: This is not actually in the Blue Book."
   ^ self.
 
-+ error: aMessage
+- error: aString
+  "Report to the user that an error occurred in
+  the context of responding to a message to the
+  receiver. The report uses the argument,
+  aString, as part of the error notification comment."
   <primitive: 216>
 
+- doesNotUnderstand: aMessage 
+  "Report to the user that the receiver does not understand the argument, aMessage, as a message."
+  self error: aMessage
+
+- primitiveFailed
+  "Announce that a primitive has failed and there is no appropriate 
+  Smalltalk code to run."
+
+  self error: 'a primitive has failed'
+	
+- shouldNotImplement
+  "Announce that, although the receiver inherits this message, it should 
+  not implement it."
+
+  self error: 'This message is not appropriate for this object'
+
+- subclassResponsibility
+  "This message sets up a framework for the behavior of the class' 
+  subclasses. Announce that the subclass should have implemented this 
+  message."
+
+  self error: 'My subclass should have overridden one of my messages.'
+	
 + testClassMethod
   Transcript show: 'test'; cr.

--- a/src/main/smalltalk/st/redline/TestCase.st
+++ b/src/main/smalltalk/st/redline/TestCase.st
@@ -4,13 +4,13 @@ Object < #TestCase
   self subclassResponsibility.
 
 - assert: anObject equals: expectedObject withMessage: aString
-  anObject = expectedObject ifFalse: [ Object error: aString ].
+  anObject = expectedObject ifFalse: [ self error: aString ].
 
 - assert: anObject isNotEqualTo: unexpectedObject withMessage: aString
-  anObject = unexpectedObject ifTrue: [ Object error: aString ].
+  anObject = unexpectedObject ifTrue: [ self error: aString ].
 
 - assertTrue: aCondition withMessage: aString
-  aCondition ifFalse: [ Object error: aString ].
+  aCondition ifFalse: [ self error: aString ].
 
 - assertFalse: aCondition withMessage: aString
-  aCondition ifTrue: [ Object error: aString ].
+  aCondition ifTrue: [ self error: aString ].

--- a/src/test/smalltalk/st/redline/ObjectTest.st
+++ b/src/test/smalltalk/st/redline/ObjectTest.st
@@ -24,6 +24,7 @@ TestCase < #ObjectTest
   self testAtPut.
   self testSize.
   self testYourself.
+  " self testDoesNotUnderstand. Cannot really be tested yet -- need something like aBlock ifError:... "
 
 - testIsKindOfObject
   self assertTrue: (object1 isKindOf: Object) withMessage: 'Object new should be isKindOf Object'.  
@@ -132,16 +133,11 @@ TestCase < #ObjectTest
 - testYourself
   self assertTrue: object1 yourself == object1 withMessage: 'yourself should answer self'.
 
+- testDoesNotUnderstand
+  self shouldFail.
 
 - testWIP
   "Not ready yet..."  
   object1 := WriteStream on: String new.
   object1 nextPutAll: 'test'.
   self assert: object1 printString equals: 'anObject' withMessage: 'testing #printString'.
-
-
-
-
-
-
-


### PR DESCRIPTION
Some of these changes should be examined carefully. In particular:
- I moved Object>error: from a class method to an instance method (as per Blue Book). Everything seems to be ok still.
- I changed TestCase assert methods to say "self error:.." instead of "Object error:..." , as per the above change.
- I added doesNotUnderstand: to Object, but I did not try to implement Primitives>sendDoesNotUnderstand in java. I could take a shot at it, but I assume James can do it much faster than I.
