### PR TITLE
Cleaning up the POM for Maven Central push

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,5 +296,33 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>release-sign-artifacts</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.4</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>    
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This adds the license, SCM and developer data to the POM.
