### PR TITLE
Put back NoOpAnalyserTest with tests for only methods with a body.

### DIFF
--- a/src/test/java/st/redline/compiler/NoOpAnalyserTest.java
+++ b/src/test/java/st/redline/compiler/NoOpAnalyserTest.java
@@ -1,0 +1,32 @@
+/* Redline Smalltalk, Copyright (c) James C. Ladd. All rights reserved. See LICENSE in the root of this distribution */
+package st.redline.compiler;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+public class NoOpAnalyserTest {
+
+    NoOpAnalyser analyser;
+    Analyser parent;
+
+    @Before
+    public void setup() {
+        parent = mock(Analyser.class);
+        analyser = new NoOpAnalyser(parent);
+    }
+
+    @Test
+    public void shouldAlwaysSkipBlockVisit() {
+        Block block = mock(Block.class);
+        assertTrue(analyser.skipBlockVisit(block));
+    }
+
+    @Test
+    public void shouldAlwaysHaveClassBytesOfZeroSize() {
+        assertNotNull(analyser.classBytes());
+        assertEquals(analyser.classBytes().length, 0);
+    }
+}


### PR DESCRIPTION
...do nothing, hence the noOp name.
