### PR TITLE
Fix PrimObjectTest#shouldThrowExceptionWhenBlockToBeCompiledNotFound

### DIFF
--- a/src/test/java/st/redline/core/PrimObjectTest.java
+++ b/src/test/java/st/redline/core/PrimObjectTest.java
@@ -50,7 +50,7 @@ public class PrimObjectTest {
 
 	@Test (expected = IllegalStateException.class)
 	public void shouldThrowExceptionWhenBlockToBeCompiledNotFound() {
-		new PrimObject().block("st/redline/core/Thing$M1", null);
+		new PrimObject().block("st/redline/core/Thing$M2", null);
 	}
 
 	@Test


### PR DESCRIPTION
There is no guarantee that JUnit test cases run in top to bottom order. If the
shouldCreateInstanceOfExistingBlockWhenBlockCalledWithNameOfRegisteredBlock
test case runs first, shouldThrowExceptionWhenBlockToBeCompiledNotFound will
fail because "st/redline/core/Thing$M1" is registered to the globablly visible
PrimObject.BLOCKS.

The failure is visible in the following Travis build:

  https://travis-ci.org/redline-smalltalk/redline-smalltalk/jobs/3304772

Signed-off-by: Pekka Enberg penberg@kernel.org
