### PR TITLE
Added 'self' as receiver to 'import:' selector so as not to cause confusion.

### DIFF
--- a/src/test/smalltalk/st/redline/JavaAdaptionExample.st
+++ b/src/test/smalltalk/st/redline/JavaAdaptionExample.st
@@ -1,5 +1,5 @@
-import: 'com.friendly.Test' as: 'Test'.
-import: 'java.util.ArrayList' as: 'JList'.
+self import: 'com.friendly.Test' as: 'Test'.
+self import: 'java.util.ArrayList' as: 'JList'.
 
 Transcript  show: '1aa'; cr.
 Test new.

--- a/src/test/smalltalk/st/redline/ShowGreetingAdaptor.st
+++ b/src/test/smalltalk/st/redline/ShowGreetingAdaptor.st
@@ -1,2 +1,2 @@
-import: 'com.friendly.Greeting' as: 'Greeter'.
+self import: 'com.friendly.Greeting' as: 'Greeter'.
 Greeter new say.

--- a/src/test/smalltalk/st/redline/Web.st
+++ b/src/test/smalltalk/st/redline/Web.st
@@ -1,6 +1,6 @@
 " Redline Smalltalk, Copyright (c) James C. Ladd. All rights reserved. See LICENSE in the root of this distribution "
 
-import: 'st.redline.stout.Stout'.
+self import: 'st.redline.stout.Stout'.
 
 Stout < #Web.
 

--- a/src/test/smalltalk/st/redline/XGreetingCaller.st
+++ b/src/test/smalltalk/st/redline/XGreetingCaller.st
@@ -1,4 +1,4 @@
-import: 'st.redline.XGreeting'.
+self import: 'st.redline.XGreeting'.
 
 Object < #XGreetingCaller.
 

--- a/src/test/smalltalk/st/redline/XGreetingCallerCaller.st
+++ b/src/test/smalltalk/st/redline/XGreetingCallerCaller.st
@@ -1,5 +1,5 @@
-import: 'st.redline.XGreetingCaller'.
-import: 'st.redline.XGreeting'.
+self import: 'st.redline.XGreetingCaller'.
+self import: 'st.redline.XGreeting'.
 
 XGreeting new sayHello.
 XGreetingCaller new works.


### PR DESCRIPTION
...de a preceeding receiver 'self'. This removed some reported confusion.
