### PR TITLE
Fixed test PrimObjectTest#variableAtShouldCallResolveObject.

### DIFF
--- a/src/test/java/st/redline/core/PrimObjectTest.java
+++ b/src/test/java/st/redline/core/PrimObjectTest.java
@@ -110,6 +110,7 @@ public class PrimObjectTest {
 		when(primObjectClass.indexOfVariable("Thing")).thenReturn(0);
 		primObject.cls(primObjectClass);
 		PrimObject spy = spy(primObject);
+		doReturn(spy.cls()).when(spy).resolveObject("Thing");
 		spy.variableAt("Thing");
 		verify(spy).resolveObject("Thing");
 	}


### PR DESCRIPTION
This test was failing because there was no class named `Thing`.  Since the intention of this test is only to make sure that `resolveObject` is called for non-attribute names given to `variableAt`, I have stubbed `resolveObject` out in the spy object.

Signed-off-by: JONNALAGADDA Srinivas js@ojuslabs.com
