### PR TITLE
Fix #186 Object>>size for Collection classes.

### DIFF
--- a/src/main/java/st/redline/lang/ProtoObject.java
+++ b/src/main/java/st/redline/lang/ProtoObject.java
@@ -322,7 +322,16 @@ public class ProtoObject {
     }
 
     public ProtoObject p7(ProtoObject receiver, PrimContext context) {
-        throw new IllegalStateException("Implement primitive.");
+        // (Small)Integer =
+        ProtoObject arg = context.argumentAt(0);
+        if (arg.javaValue() instanceof BigDecimal) {
+            BigDecimal argValue = (BigDecimal)arg.javaValue();
+            BigDecimal receiverValue = (BigDecimal)receiver.javaValue();
+            return smalltalkBoolean(receiverValue.compareTo(argValue) == 0);
+        } else {
+            // Handle other numberical args
+            throw new IllegalStateException("Implement primitive.");
+        }
     }
 
     public ProtoObject p8(ProtoObject receiver, PrimContext context) {
@@ -545,8 +554,8 @@ public class ProtoObject {
         // Object size.
         Object value = receiver.javaValue();
         if (value instanceof List)
-            return smalltalkNumber(((List) value).size());
-        return smalltalkNumber("0");
+            return receiver.smalltalkNumber(((List) value).size() - 1);
+        return receiver.smalltalkNumber("0");
     }
 
     public ProtoObject p63(ProtoObject receiver, PrimContext context) {

--- a/src/main/smalltalk/st/redline/kernel/Integer.st
+++ b/src/main/smalltalk/st/redline/kernel/Integer.st
@@ -2,6 +2,14 @@
 
 Number subclass: #Integer.
 
+"category: comparing"
+
+- = aNumber
+    "Answer of aNumber is equal to the receiver. The Blue Book specifies this primitive for SmallInteger,
+     however we are not implementing that class so can use it here."
+    <primitive: 7>.
+    ^ super = aNumber.
+
 "category: factorization and divisibility"
 
 - factorial

--- a/src/test/smalltalk/st/redline/kernel/CollectionTest.st
+++ b/src/test/smalltalk/st/redline/kernel/CollectionTest.st
@@ -1,0 +1,15 @@
+"Redline Smalltalk, Copyright (c) James C. Ladd. All rights reserved. See LICENSE in the root of this distribution."
+
+self import: 'st.redline.test.TestCase'.
+
+TestCase subclass: #CollectionTest.
+
+- test
+    self testSize.
+
+- testSize
+    | array |
+    array := #().
+    self assert: array size equals: 0 withMessage: 'should have size 0'.
+    array := #(1 3 5 7 9).
+    self assert: array size equals: 5 withMessage: 'should have size 5'.

--- a/src/test/smalltalk/st/redline/kernel/TestSuite.st
+++ b/src/test/smalltalk/st/redline/kernel/TestSuite.st
@@ -14,6 +14,8 @@ Object subclass: #TestSuite.
     FalseTest new test.
     self show: 'Running ObjectTests'.
     ObjectTest new test.
+    self show: 'Running CollectionTests'.
+    CollectionTest new test.
 
 - show: message
     Transcript show: message; cr.


### PR DESCRIPTION
Previously, this was reporting the size of the underlying Java collection which has an unused sentinel at index 0 so reports as 1 larger than the Smalltalk version.

Was required to implement Integer>>=. Since we are not implementing SmallInteger, this was done using the SmallInteger>>= primitive (p7). The version only handles Integer comparisons. Fraction and Float
comparisons will need to be added.

Signed-off-by: Mark Bush <redline@bushnet.org>