### PR TITLE
Implemented String concatenation

### DIFF
--- a/src/main/java/st/redline/lang/PrimSubclass.java
+++ b/src/main/java/st/redline/lang/PrimSubclass.java
@@ -1,6 +1,9 @@
 /* Redline Smalltalk, Copyright (c) James C. Ladd. All rights reserved. See LICENSE in the root of this distribution. */
 package st.redline.lang;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import st.redline.classloader.SmalltalkClassLoader;
 
 public class PrimSubclass extends ProtoObject {
@@ -12,7 +15,18 @@ public class PrimSubclass extends ProtoObject {
     protected ProtoObject invoke(ProtoObject receiver, PrimContext context) {
         SmalltalkClassLoader smalltalkClassLoader = classLoader();
         String name = subclassNameFrom(context);
-        ProtoObject sublcass = createSubclass(smalltalkClassLoader.METACLASS, (ProtoClass) receiver, name);
+        Map<String, Integer> instVarMap = new HashMap<String,Integer>();
+        if (context.arguments != null && context.arguments.length > 1) {
+            ProtoObject instVars = context.argumentAt(1);
+            if (instVars != null && instVars.javaValue() != null) {
+                String[] instVarNames = ((String)instVars.javaValue()).trim().split("\\s+");
+                int instVarIndex = 1;
+                for (String instVarName : instVarNames) {
+                  instVarMap.put(instVarName, instVarIndex++);
+                }
+            }
+        }
+        ProtoObject sublcass = createSubclass(smalltalkClassLoader.METACLASS, (ProtoClass) receiver, name, instVarMap);
         registerClass(smalltalkClassLoader, receiver, name, sublcass);
         return sublcass;
     }
@@ -22,10 +36,10 @@ public class PrimSubclass extends ProtoObject {
         smalltalkClassLoader.registerSmalltalkClass(fullyQualifiedName, subclass);
     }
 
-    private ProtoObject createSubclass(ProtoObject metaclass, ProtoClass receiver, String name) {
+    private ProtoObject createSubclass(ProtoObject metaclass, ProtoClass receiver, String name, Map<String,Integer> instVarMap) {
         ProtoClass newMetaclass = ((ProtoClass) receiver.selfclass).subclass();
         newMetaclass.selfclass = metaclass;
-        ProtoClass newClass = newMetaclass.create(name);
+        ProtoClass newClass = newMetaclass.create(name, instVarMap);
         newClass.superclass = receiver;
         return newClass;
     }

--- a/src/main/java/st/redline/lang/ProtoClass.java
+++ b/src/main/java/st/redline/lang/ProtoClass.java
@@ -30,6 +30,16 @@ public class ProtoClass extends ProtoObject {
         return metaclass;
     }
 
+    public ProtoClass create(String name, Map<String, Integer> instVarMap) {
+        ProtoClass metaclass = create(name);
+        metaclass.variableIndexes = instVarMap;
+        int attributeSize = instVarMap.size();
+        if (attributeSize > 0) {
+          metaclass.attributes = new ProtoObject[attributeSize + 1];
+        }
+        return metaclass;
+    }
+
     public ProtoClass subclass() {
         ProtoClass subclass = new ProtoClass();
         subclass.superclass = this;

--- a/src/main/java/st/redline/lang/ProtoObject.java
+++ b/src/main/java/st/redline/lang/ProtoObject.java
@@ -322,7 +322,16 @@ public class ProtoObject {
     }
 
     public ProtoObject p7(ProtoObject receiver, PrimContext context) {
-        throw new IllegalStateException("Implement primitive.");
+        // (Small)Integer =
+        ProtoObject arg = context.argumentAt(0);
+        if (arg.javaValue() instanceof BigDecimal) {
+            BigDecimal argValue = (BigDecimal)arg.javaValue();
+            BigDecimal receiverValue = (BigDecimal)receiver.javaValue();
+            return smalltalkBoolean(receiverValue.compareTo(argValue) == 0);
+        } else {
+            // Handle other numberical args
+            throw new IllegalStateException("Implement primitive.");
+        }
     }
 
     public ProtoObject p8(ProtoObject receiver, PrimContext context) {
@@ -545,8 +554,8 @@ public class ProtoObject {
         // Object size.
         Object value = receiver.javaValue();
         if (value instanceof List)
-            return smalltalkNumber(((List) value).size());
-        return smalltalkNumber("0");
+            return receiver.smalltalkNumber(((List) value).size() - 1);
+        return receiver.smalltalkNumber("0");
     }
 
     public ProtoObject p63(ProtoObject receiver, PrimContext context) {

--- a/src/main/java/st/redline/lang/ProtoObject.java
+++ b/src/main/java/st/redline/lang/ProtoObject.java
@@ -117,12 +117,20 @@ public class ProtoObject {
         return instanceOfWith("Integer", new BigDecimal(value));
     }
 
+    public ProtoObject smalltalkNumber(BigDecimal javaValue) {
+        return instanceOfWith("Integer", javaValue);
+    }
+
     public ProtoObject smalltalkNumber(Object javaValue) {
         return instanceOfWith("Integer", new BigDecimal((String) javaValue));
     }
 
     public ProtoObject smalltalkString(Object javaValue) {
         return instanceOfWith("String", javaValue);
+    }
+
+    public ProtoObject smalltalkCharacter(Object javaValue) {
+        return instanceOfWith("Character", javaValue);
     }
 
     public ProtoObject smalltalkArray(int size) {
@@ -184,6 +192,10 @@ public class ProtoObject {
         if (index != 0)
             return attributes[index];
         return resolveObject(name);
+    }
+
+    public static ProtoObject variablePutAtIn(ProtoObject object, String name, ProtoObject receiver) {
+      return receiver.variableAtPut(name, object);
     }
 
     public ProtoObject variableAtPut(String name, ProtoObject object) {
@@ -298,27 +310,81 @@ public class ProtoObject {
     //
 
     public ProtoObject p1(ProtoObject receiver, PrimContext context) {
-        throw new IllegalStateException("Implement primitive.");
+        // (Small)Integer +
+        ProtoObject arg = context.argumentAt(0);
+        if (arg.javaValue() instanceof BigDecimal) {
+            BigDecimal argValue = (BigDecimal)arg.javaValue();
+            BigDecimal receiverValue = (BigDecimal)receiver.javaValue();
+            return smalltalkNumber(receiverValue.add(argValue));
+        } else {
+            // Handle other numberical args
+            throw new IllegalStateException("Implement primitive.");
+        }
     }
 
     public ProtoObject p2(ProtoObject receiver, PrimContext context) {
-        throw new IllegalStateException("Implement primitive.");
+        // (Small)Integer -
+        ProtoObject arg = context.argumentAt(0);
+        if (arg.javaValue() instanceof BigDecimal) {
+            BigDecimal argValue = (BigDecimal)arg.javaValue();
+            BigDecimal receiverValue = (BigDecimal)receiver.javaValue();
+            return smalltalkNumber(receiverValue.subtract(argValue));
+        } else {
+            // Handle other numberical args
+            throw new IllegalStateException("Implement primitive.");
+        }
     }
 
     public ProtoObject p3(ProtoObject receiver, PrimContext context) {
-        throw new IllegalStateException("Implement primitive.");
+        // (Small)Integer <
+        ProtoObject arg = context.argumentAt(0);
+        if (arg.javaValue() instanceof BigDecimal) {
+            BigDecimal argValue = (BigDecimal)arg.javaValue();
+            BigDecimal receiverValue = (BigDecimal)receiver.javaValue();
+            return smalltalkBoolean(receiverValue.compareTo(argValue) < 0);
+        } else {
+            // Handle other numberical args
+            throw new IllegalStateException("Implement primitive.");
+        }
     }
 
     public ProtoObject p4(ProtoObject receiver, PrimContext context) {
-        throw new IllegalStateException("Implement primitive.");
+        // (Small)Integer >
+        ProtoObject arg = context.argumentAt(0);
+        if (arg.javaValue() instanceof BigDecimal) {
+            BigDecimal argValue = (BigDecimal)arg.javaValue();
+            BigDecimal receiverValue = (BigDecimal)receiver.javaValue();
+            return smalltalkBoolean(receiverValue.compareTo(argValue) > 0);
+        } else {
+            // Handle other numberical args
+            throw new IllegalStateException("Implement primitive.");
+        }
     }
 
     public ProtoObject p5(ProtoObject receiver, PrimContext context) {
-        throw new IllegalStateException("Implement primitive.");
+        // (Small)Integer <=
+        ProtoObject arg = context.argumentAt(0);
+        if (arg.javaValue() instanceof BigDecimal) {
+            BigDecimal argValue = (BigDecimal)arg.javaValue();
+            BigDecimal receiverValue = (BigDecimal)receiver.javaValue();
+            return smalltalkBoolean(receiverValue.compareTo(argValue) <= 0);
+        } else {
+            // Handle other numberical args
+            throw new IllegalStateException("Implement primitive.");
+        }
     }
 
     public ProtoObject p6(ProtoObject receiver, PrimContext context) {
-        throw new IllegalStateException("Implement primitive.");
+        // (Small)Integer >=
+        ProtoObject arg = context.argumentAt(0);
+        if (arg.javaValue() instanceof BigDecimal) {
+            BigDecimal argValue = (BigDecimal)arg.javaValue();
+            BigDecimal receiverValue = (BigDecimal)receiver.javaValue();
+            return smalltalkBoolean(receiverValue.compareTo(argValue) >= 0);
+        } else {
+            // Handle other numberical args
+            throw new IllegalStateException("Implement primitive.");
+        }
     }
 
     public ProtoObject p7(ProtoObject receiver, PrimContext context) {
@@ -339,11 +405,29 @@ public class ProtoObject {
     }
 
     public ProtoObject p9(ProtoObject receiver, PrimContext context) {
-        throw new IllegalStateException("Implement primitive.");
+        // (Small)Integer *
+        ProtoObject arg = context.argumentAt(0);
+        if (arg.javaValue() instanceof BigDecimal) {
+            BigDecimal argValue = (BigDecimal)arg.javaValue();
+            BigDecimal receiverValue = (BigDecimal)receiver.javaValue();
+            return smalltalkNumber(receiverValue.multiply(argValue));
+        } else {
+            // Handle other numberical args
+            throw new IllegalStateException("Implement primitive.");
+        }
     }
 
     public ProtoObject p10(ProtoObject receiver, PrimContext context) {
-        throw new IllegalStateException("Implement primitive.");
+        // (Small)Integer /
+        ProtoObject arg = context.argumentAt(0);
+        if (arg.javaValue() instanceof BigDecimal) {
+            BigDecimal argValue = (BigDecimal)arg.javaValue();
+            BigDecimal receiverValue = (BigDecimal)receiver.javaValue();
+            return smalltalkNumber(receiverValue.divide(argValue));
+        } else {
+            // Handle other numberical args
+            throw new IllegalStateException("Implement primitive.");
+        }
     }
 
     public ProtoObject p11(ProtoObject receiver, PrimContext context) {
@@ -431,7 +515,16 @@ public class ProtoObject {
     }
 
     public ProtoObject p32(ProtoObject receiver, PrimContext context) {
-        throw new IllegalStateException("Implement primitive.");
+        // (Small)Integer //
+        ProtoObject arg = context.argumentAt(0);
+        if (arg.javaValue() instanceof BigDecimal) {
+            BigDecimal argValue = (BigDecimal)arg.javaValue();
+            BigDecimal receiverValue = (BigDecimal)receiver.javaValue();
+            return smalltalkNumber(receiverValue.divide(argValue, BigDecimal.ROUND_FLOOR));
+        } else {
+            // Handle other numberical args
+            throw new IllegalStateException("Implement primitive.");
+        }
     }
 
     public ProtoObject p33(ProtoObject receiver, PrimContext context) {
@@ -553,12 +646,21 @@ public class ProtoObject {
     public ProtoObject p62(ProtoObject receiver, PrimContext context) {
         // Object size.
         Object value = receiver.javaValue();
-        if (value instanceof List)
+        if (value instanceof List) {
             return receiver.smalltalkNumber(((List) value).size() - 1);
+        } else if (value instanceof String) {
+          return receiver.smalltalkNumber(((String) value).length());
+        }
         return receiver.smalltalkNumber("0");
     }
 
     public ProtoObject p63(ProtoObject receiver, PrimContext context) {
+        // String at:.
+        Object value = receiver.javaValue();
+        if (value instanceof String) {
+          int index = context.intArgumentAt(0);
+          return receiver.smalltalkCharacter(((String) value).substring(index-1, index));
+        }
         throw new IllegalStateException("Implement primitive.");
     }
 
@@ -587,15 +689,42 @@ public class ProtoObject {
     }
 
     public ProtoObject p70(ProtoObject receiver, PrimContext context) {
-        // The primitiveNew routine creates a new instance of the receiver (a class)
+        // The primitive New routine creates a new instance of the receiver (a class)
         ProtoClass aClass = (ProtoClass) receiver;
         ProtoObject anInstance = new ProtoObject();
         anInstance.selfclass = aClass;
+        if (aClass.attributes != null) {
+          anInstance.attributes = new ProtoObject[aClass.attributes.length];
+        }
         return anInstance;
     }
 
     public ProtoObject p71(ProtoObject receiver, PrimContext context) {
-        throw new IllegalStateException("Implement primitive.");
+        // The primitive New: routine creates a new instance of the receiver (a class)
+        // with the specified number of indexed instance variables which we implement
+        // here with a List
+        int size = context.intArgumentAt(0);
+        ProtoClass aClass = (ProtoClass) receiver;
+        ProtoObject anInstance = new ProtoObject();
+        anInstance.selfclass = aClass;
+        if (aClass.attributes != null) {
+          anInstance.attributes = new ProtoObject[aClass.attributes.length];
+        }
+        if (aClass.name.equals("String")) {
+            String string = "";
+            while (string.length() < size) {
+                string += "\0";
+            }
+            anInstance.javaValue(string);
+        } else {
+            List<ProtoObject> array = new ArrayList<ProtoObject>();
+            ProtoObject initialElement = nil();
+            array.add(initialElement); // we add NIL at index 0 because smalltalk indexes start at 1.
+            while (array.size() < size + 1)
+                array.add(initialElement);
+            anInstance.javaValue(array);
+        }
+        return anInstance;
     }
 
     public ProtoObject p72(ProtoObject receiver, PrimContext context) {
@@ -735,6 +864,25 @@ public class ProtoObject {
     }
 
     public ProtoObject p105(ProtoObject receiver, PrimContext context) {
+        // String replaceFrom:to:with:startingAt:
+        Object value = receiver.javaValue();
+        if (value instanceof String) {
+          String valueString = (String)value;
+          int start = context.intArgumentAt(0);
+          int stop = context.intArgumentAt(1);
+          Object withObject = context.argumentAt(2).javaValue();
+          int repStart = context.intArgumentAt(3);
+          if (withObject instanceof String) {
+            String replacementString = (String)withObject;
+            int replacementLength = stop + 1 - start;
+            String replacementSubstring = replacementString.substring(repStart-1, repStart+replacementLength-1);
+            String newString = valueString.substring(0, start-1);
+            newString += replacementSubstring;
+            newString += valueString.substring(start+replacementLength-1);
+            receiver.javaValue(newString);
+            return receiver;
+          }
+        }
         throw new IllegalStateException("Implement primitive.");
     }
 
@@ -756,7 +904,21 @@ public class ProtoObject {
 
     public ProtoObject p110(ProtoObject receiver, PrimContext context) {
         // Object ==
-        return smalltalkBoolean(receiver.equals(context.argumentAt(0)));
+        ProtoObject arg = context.argumentAt(0);
+        if (receiver.equals(arg)) {
+            return smalltalkBoolean(true);
+        } else if (receiver.selfclass != null
+                   && receiver.selfclass.name != null
+                   && receiver.selfclass.name.equals("Character")) {
+            String receiverChar = (String)receiver.javaValue();
+            if (arg.selfclass.name.equals("Character")) {
+                String argChar = (String)arg.javaValue();
+                return smalltalkBoolean(receiverChar.equals(argChar));
+            } else {
+                return smalltalkBoolean(false);
+            }
+        }
+        return smalltalkBoolean(false);
     }
 
     public ProtoObject p111(ProtoObject receiver, PrimContext context) {
@@ -893,7 +1055,15 @@ public class ProtoObject {
 
     public ProtoObject p138(ProtoObject receiver, PrimContext context) {
         // BlockClojure -> whileTrue: aBlock
-        throw new IllegalStateException("Implement primitive.");
+        // Evaluate the argument, aBlock, as long as the value of the receiver is true.
+        ProtoObject aBlockResult = nil();
+        ProtoObject aBlock = context.argumentAt(0);
+        ProtoObject receiverResult = receiver.perform("value");
+        while (receiverResult.isTrueObject()) {
+            aBlockResult = aBlock.perform("value");
+            receiverResult = receiver.perform("value");
+        }
+        return aBlockResult;
     }
 
     public ProtoObject p139(ProtoObject receiver, PrimContext context) {

--- a/src/main/smalltalk/st/redline/kernel/Behavior.st
+++ b/src/main/smalltalk/st/redline/kernel/Behavior.st
@@ -59,11 +59,11 @@ Object subclass: #Behavior.
 - new: anInteger
     "Answer an instance of the receiver with anlnteger number of indexed variables. Report an error if the receiver is
      not indexable."
-    self notImplementedYet.
+    ^ (self basicNew: anInteger) initialize.
 
 - basicNew: anInteger
     "Same as basicNew, except this method should not be overridden in a subclass."
-    self notImplementedYet.
+    <primitive: 71>.
 
 "category: creating a class hierarchy"
 

--- a/src/main/smalltalk/st/redline/kernel/Character.st
+++ b/src/main/smalltalk/st/redline/kernel/Character.st
@@ -26,6 +26,9 @@ Magnitude subclass: #Character.
      message digitValue: for the correspondences)."
     self notImplementedYet.
 
+- = aCharacter
+    <primitive: 110>
+
 "category: testing"
 
 - isAlphaNumeric

--- a/src/main/smalltalk/st/redline/kernel/Integer.st
+++ b/src/main/smalltalk/st/redline/kernel/Integer.st
@@ -2,6 +2,14 @@
 
 Number subclass: #Integer.
 
+"category: comparing"
+
+- = aNumber
+    "Answer of aNumber is equal to the receiver. The Blue Book specifies this primitive for SmallInteger,
+     however we are not implementing that class so can use it here."
+    <primitive: 7>.
+    ^ super = aNumber.
+
 "category: factorization and divisibility"
 
 - factorial

--- a/src/main/smalltalk/st/redline/kernel/Integer.st
+++ b/src/main/smalltalk/st/redline/kernel/Integer.st
@@ -2,13 +2,51 @@
 
 Number subclass: #Integer.
 
+"category: arithmetic"
+
+- + aNumber
+    "Answer the sum of the receiver and the argument, aNumber."
+    <primitive: 1>.
+
+- - aNumber
+    "Answer the difference between the receiver and the argument, aNumber."
+    <primitive: 2>.
+
+- * aNumber
+    "Answer the result of multiplying the receiver by the argument, aNumber."
+    <primitive: 9>.
+
+- / aNumber
+    "Answer the result of dividing the receiver by the argument, aNumber. Note that since as much precision as possible
+     is retained, if the division is not exact, the result will be an instance of Fraction."
+    <primitive: 10>.
+
+- // aNumber
+    "Answer the quotient of dividing the receiver by the argument, aNumber with truncation towards negative infinity."
+    <primitive: 32>.
+
 "category: comparing"
 
 - = aNumber
-    "Answer of aNumber is equal to the receiver. The Blue Book specifies this primitive for SmallInteger,
+    "Answer if aNumber is equal to the receiver. The Blue Book specifies this primitive for SmallInteger,
      however we are not implementing that class so can use it here."
     <primitive: 7>.
-    ^ super = aNumber.
+
+- < aNumber
+    "Answer whether the receiver is less than the argument."
+    <primitive: 3>.
+
+- <= aNumber
+    "Answer whether the receiver is less than the argument."
+    <primitive: 5>.
+
+- > aNumber
+    "Answer whether the receiver is less than the argument."
+    <primitive: 4>.
+
+- >= aNumber
+    "Answer whether the receiver is less than the argument."
+    <primitive: 6>.
 
 "category: factorization and divisibility"
 

--- a/src/main/smalltalk/st/redline/kernel/Interval.st
+++ b/src/main/smalltalk/st/redline/kernel/Interval.st
@@ -1,15 +1,125 @@
 "Redline Smalltalk, Copyright (c) James C. Ladd. All rights reserved. See LICENSE in the root of this distribution."
 
-SequenceableCollection subclass: #Interval.
+SequenceableCollection subclass: #Interval
+                       instanceVariableNames: 'start stop step'
+                       classVariableNames: ''
+                       poolDictionaries: ''
+                       classInstanceVariableNames: ''.
 
 "category: instance creation"
 
-- from: startInteger to: stopInteger
++ from: startInteger to: stopInteger
     "Answer an instance of class Interval, starting with the number startInteger, ending with the number stopInteger,
      and using the increment 1 to compute each successive element."
-    self notImplementedYet.
+    ^ self new setFrom: startInteger to: stopInteger by: 1.
 
-- from: startInteger to: stopInteger by: stepInteger
++ from: startInteger to: stopInteger by: stepInteger
     "Answer an instance of Interval, starting with the number startInteger, ending with the number stopInteger, and
      using the increment stepInteger to compute each successive element."
-    self notImplementedYet.
+    ^ self new setFrom: startInteger to: stopInteger by: stepInteger.
+
+"category: accessing"
+
+- species
+    "Answer the preferred class for reconstructing the receiver."
+    ^ Array
+
+- size
+    "Answer the size of this Interval."
+    step < 0
+      ifTrue: [
+        start < stop
+          ifTrue: [ ^ 0. ]
+          ifFalse: [ ^ stop - start // step + 1. ].
+      ]
+      ifFalse: [
+        stop < start
+          ifTrue: [ ^ 0. ]
+          ifFalse: [ ^ stop - start // step + 1. ].
+      ].
+
+- at: index
+    "Answer the element in this Interval at index."
+    ^ (index >= 1 and: [ index <= self size ])
+      ifTrue: [ start + (step * (index - 1)). ]
+      ifFalse: [ self errorSubscriptBounds: index. ].
+
+- at: index put: anObject
+    self error: 'you cannot store into an Interval'.
+
+"category: adding"
+
+- add: anObject
+    self error: 'elements cannot be added to an Interval'.
+
+"category: removing"
+
+- remove: anObject
+    self error: 'elements cannot be removed from an Interval'.
+
+"category: enumerating"
+
+- do: aBlock
+    "Evaluate aBlock for each element in the receiver."
+    | aValue |
+    aValue := start.
+    step < 0
+      ifTrue: [ | innerBlock innerValue |
+        innerBlock := aBlock. "FIXME: outer values not available to nested blocks!"
+        innerValue := aValue.
+        [ stop <= innerValue ]
+          whileTrue: [
+            innerBlock value: innerValue.
+            innerValue := innerValue + step.
+          ].
+      ]
+      ifFalse: [ | innerBlock innerValue |
+        innerBlock := aBlock. "FIXME: outer values not available to nested blocks!"
+        innerValue := aValue.
+        [ stop >= innerValue ]
+          whileTrue: [
+            innerBlock value: innerValue.
+            innerValue := innerValue + step.
+          ].
+      ].
+
+- collect: aBlock
+    "Evaluate aBlock for each element in the receiver and collect the results into an Array."
+    | nextValue i result |
+    result := self species new: self size.
+    nextValue := start.
+    i := 1.
+    step < 0
+      ifTrue: [ | innerBlock innerValue innerI innerResult |
+        innerBlock := aBlock. "FIXME: outer values not available to nested blocks!"
+        innerValue := nextValue.
+        innerI := i.
+        innerResult := result.
+        [ stop <= innerValue ]
+          whileTrue: [
+            innerResult at: innerI put: (innerBlock value: innerValue).
+            innerValue := innerValue + step.
+            innerI := innerI + 1.
+          ].
+      ]
+      ifFalse: [ | innerBlock innerValue innerI innerResult |
+        innerBlock := aBlock. "FIXME: outer values not available to nested blocks!"
+        innerValue := nextValue.
+        innerI := i.
+        innerResult := result.
+        [ stop >= innerValue ]
+          whileTrue: [
+            innerResult at: innerI put: (innerBlock value: innerValue).
+            innerValue := innerValue + step.
+            innerI := innerI + 1.
+          ].
+      ].
+      ^ result.
+
+"category: private"
+
+- setFrom: startInteger to: stopInteger by: stepInteger
+    "Set the start, stop and step for this Interval."
+    start := startInteger.
+    stop := stopInteger.
+    step := stepInteger.

--- a/src/main/smalltalk/st/redline/kernel/Magnitude.st
+++ b/src/main/smalltalk/st/redline/kernel/Magnitude.st
@@ -6,7 +6,7 @@ Object subclass: #Magnitude.
 
 - < aMagnitude
     "Answer whether the receiver is less than the argument."
-    self notImplementedYet.
+    self subclassResponsibility.
 
 - <= aMagnitude
     "Answer whether the receiver is less than or equal to the argument."

--- a/src/main/smalltalk/st/redline/kernel/Number.st
+++ b/src/main/smalltalk/st/redline/kernel/Number.st
@@ -6,20 +6,20 @@ Magnitude subclass: #Number.
 
 - + aNumber
     "Answer the sum of the receiver and the argument, aNumber."
-    self notImplementedYet.
+    self subclassResponsibility.
 
 - - aNumber
     "Answer the difference between the receiver and the argument, aNumber."
-    self notImplementedYet.
+    self subclassResponsibility.
 
 - * aNumber
     "Answer the result of multiplying the receiver by the argument, aNumber."
-    self notImplementedYet.
+    self subclassResponsibility.
 
 - / aNumber
     "Answer the result of dividing the receiver by the argument, aNumber. Note that since as much precision as possible
      is retained, if the division is not exact, the result will be an instance of Fraction."
-    self notImplementedYet.
+    self subclassResponsibility.
 
 - // aNumber
     "Answer the integer quotient defined by division with truncation toward negative infinity."
@@ -171,19 +171,19 @@ Magnitude subclass: #Number.
 - to: stop
     "Answer an Interval from the receiver up to the argument, stop, with each next element computed by incrementing the
      previous one by 1."
-    self notImplementedYet.
+    ^ Interval from: self to: stop.
 
 - to: stop by: step
     "Answer an Interval from the receiver up to the argument, stop, with each next element computed by incrementing the
      previous one by step."
-    self notImplementedYet.
+    ^ Interval from: self to: stop by: step.
 
 - to: stop do: aBlock
     "Create an Interval from the receiver up to the argument, stop, incrementing by 1. Evaluate the argument, aBlock,
      for each element of the Interval."
-    self notImplementedYet.
+    (Interval from: self to: stop) do: aBlock.
 
 - to: stop by: step do: aBlock
     "Create an Interval from the receiver up to the argument, stop, incrementing by step. Evaluate the argument, aBlock,
      for each element of the Interval."
-    self notImplementedYet.
+    (Interval from: self to: stop by: step) do: aBlock.

--- a/src/main/smalltalk/st/redline/kernel/Object.st
+++ b/src/main/smalltalk/st/redline/kernel/Object.st
@@ -27,6 +27,10 @@ ProtoObject subclass: #Object.
     "Primitive. Answer the object which is the receiver's class."
     <primitive: 111>
 
+- species
+    "Answer the preferred class for constructing the receiver."
+    <primitive: 111>
+
 - yourself
     ^ self.
 
@@ -200,6 +204,10 @@ ProtoObject subclass: #Object.
 - notImplementedYet
     "Announce that, although the receiver inherits this message, it is not implemented YET."
     self error: 'This message is not implemented yet. Please implement is via a Test.'.
+
+- errorSubscriptBounds: anIndex
+    "Report that the specified index is out of bounds for the receiver."
+    self error: 'The index is out of range for this object.'.
 
 "category: testing"
 

--- a/src/main/smalltalk/st/redline/kernel/SequenceableCollection.st
+++ b/src/main/smalltalk/st/redline/kernel/SequenceableCollection.st
@@ -2,6 +2,18 @@
 
 Collection subclass: #SequenceableCollection.
 
+"category: comparing"
+
+- = aCollection
+    "Answer if aCollection is equal to the receiver."
+    self == aCollection ifTrue: [ ^ true ].
+    (aCollection isKindOf: SequenceableCollection) ifFalse: [ false ].
+    self size = aCollection size ifFalse: [ ^ false ].
+    1 to: self size do: [ :index |
+      (self at: index) = (aCollection at: index) ifFalse: [ ^ false ].
+    ].
+    ^ true.
+
 "category: accessing"
 
 - atAll: aCollection put: anObject
@@ -53,14 +65,24 @@ Collection subclass: #SequenceableCollection.
      the element of replacementCollection whose index is repStart. Answer the receiver. No range checks are performed,
      except if the receiver is the same as replacementCollection but repStart is not 1, then an error reporting that
      indices are out of range will occur."
-    self notImplementedYet.
+    | index repOffset |
+    (self == replacementCollection and: [ repStart ~= 1 ])
+      ifTrue: [ self errorSubscriptBounds: self size + 1 ].
+    index := start.
+    repOffset := repStart - start.
+    [ index <= stop ]
+      whileTrue: [
+        self at: index put: (replacementCollection at: repOffset + index).
+        index := index + 1
+      ].
+    ^ self.
 
 "category: copying"
 
 - , aSequenceableCollection
     "This is the concatenation operation. Answer a copy of the receiver with each element of the argument,
     aSequenceableCollection, added, in order."
-    self notImplementedYet.
+    ^ self copyReplaceFrom: self size + 1 to: self size with: aSequenceableCollection.
 
 - copyFrom: start to: stop
     "Answer a copy of a subset of the receiver, starting from element at index start until element at index stop."
@@ -75,7 +97,32 @@ Collection subclass: #SequenceableCollection.
      insertion; stop should be exactly start-1, start = 1 means insert before the first character, start = size + 1
      means append after last character. Otherwise, this is a replacement; start and stop have to be within the
      receiver's bounds."
-    self notImplementedYet.
+    | newSequenceableCollection newSize endReplacement |
+    newSize := self size - (stop - start + 1) + replacementCollection size.
+    endReplacement := start - 1 + replacementCollection size.
+    newSequenceableCollection := self species new: newSize.
+    start > 1
+      ifTrue: [
+        newSequenceableCollection replaceFrom: 1
+                                  to: start - 1
+                                  with: self
+                                  startingAt: 1
+      ].
+    start <= endReplacement
+      ifTrue: [
+        newSequenceableCollection replaceFrom: start
+                                  to: endReplacement
+                                  with: replacementCollection
+                                  startingAt: 1
+      ].
+    endReplacement < newSize
+      ifTrue: [
+        newSequenceableCollection replaceFrom: endReplacement + 1
+                                  to: newSize
+                                  with: self
+                                  startingAt: stop + 1
+      ].
+    ^ newSequenceableCollection.
 
 - copyWith: newElement
     "Answer a copy of the receiver that is 1 bigger than the receiver and has newElement as the last element."

--- a/src/main/smalltalk/st/redline/kernel/String.st
+++ b/src/main/smalltalk/st/redline/kernel/String.st
@@ -2,6 +2,19 @@
 
 ArrayedCollection subclass: #String.
 
+"category: accessing"
+
+- replaceFrom: start to: stop with: replacementCollection startingAt: repStart
+    "Associate each index between start and stop with the elements of the argument, replacementCollection, starting at
+     the element of replacementCollection whose index is repStart. Answer the receiver. No range checks are performed,
+     except if the receiver is the same as replacementCollection but repStart is not 1, then an error reporting that
+     indices are out of range will occur."
+    <primitive: 105>
+
+- at: anIndex
+    "Answer the character at anIndex in the receiver."
+    <primitive: 63>
+
 "category: comparing"
 
 - < aString

--- a/src/test/smalltalk/st/redline/kernel/CollectionTest.st
+++ b/src/test/smalltalk/st/redline/kernel/CollectionTest.st
@@ -1,0 +1,15 @@
+"Redline Smalltalk, Copyright (c) James C. Ladd. All rights reserved. See LICENSE in the root of this distribution."
+
+self import: 'st.redline.test.TestCase'.
+
+TestCase subclass: #CollectionTest.
+
+- test
+    self testSize.
+
+- testSize
+    | array |
+    array := #().
+    self assert: array size equals: 0 withMessage: 'should have size 0'.
+    array := #(1 3 5 7 9).
+    self assert: array size equals: 5 withMessage: 'should have size 5'.

--- a/src/test/smalltalk/st/redline/kernel/IntegerTest.st
+++ b/src/test/smalltalk/st/redline/kernel/IntegerTest.st
@@ -1,0 +1,79 @@
+"Redline Smalltalk, Copyright (c) James C. Ladd. All rights reserved. See LICENSE in the root of this distribution."
+
+self import: 'st.redline.test.TestCase'.
+
+TestCase subclass: #IntegerTest.
+
+- test
+    self testAddition.
+    self testSubtraction.
+    self testMultiplication.
+    self testDivision.
+    self testLessThan.
+    self testLessThanOrEqual.
+    self testGreaterThan.
+    self testGreaterThanOrEqual.
+    self testQuotient.
+
+- testAddition
+    self assert: 1 + 1 equals: 2 withMessage: '1 + 1 should equal 2'.
+    self assert: 548137 + 0 equals: 548137 withMessage: '548137 + 0 should equal 548137'.
+    self assert: 23 + -45 equals: -22 withMessage: '23 + -45 should equal -22'.
+    self assert: -15 + 83 equals: 68 withMessage: '-15 + 83 should equal 68'.
+
+- testSubtraction
+    self assert: 1 - 1 equals: 0 withMessage: '1 - 1 should equal 0'.
+    self assert: 548137 - 0 equals: 548137 withMessage: '548137 - 0 should equal 548137'.
+    self assert: 23 - 45 equals: -22 withMessage: '23 - 45 should equal -22'.
+    self assert: -15 - -83 equals: 68 withMessage: '-15 - -83 should equal 68'.
+
+- testMultiplication
+    self assert: 1 * 1 equals: 1 withMessage: '1 * 1 should equal 1'.
+    self assert: 548137 * 0 equals: 0 withMessage: '548137 * 0 should equal 0'.
+    self assert: 23 * -45 equals: -1035 withMessage: '23 * -45 should equal -1035'.
+    self assert: -15 * -83 equals: 1245 withMessage: '-15 * -83 should equal 1245'.
+
+- testDivision
+    self assert: 1 / 1 equals: 1 withMessage: '1 / 1 should equal 1'.
+    self assert: 0 / 548137 equals: 0 withMessage: '0 / 548137 should equal 0'.
+    "Test generation of Fraction when class is implemented"
+
+- testLessThan
+    self assertTrue: 1 < 5 withMessage: 'should be true: 1 < 5'.
+    self assertTrue: -5 < -1 withMessage: 'should be true: -5 < -1'.
+    self assertTrue: -3 < 5 withMessage: 'should be true: -3 < 5'.
+    self assertFalse: 5 < 1 withMessage: 'should be false: 5 < 1'.
+    self assertFalse: -1 < -5 withMessage: 'should be false: -1 < -5'.
+    self assertFalse: 5 < -3 withMessage: 'should be false: 5 < -3'.
+
+- testLessThanOrEqual
+    self assertTrue: 1 <= 5 withMessage: 'should be true: 1 <= 5'.
+    self assertTrue: -5 <= -1 withMessage: 'should be true: -5 <= -1'.
+    self assertTrue: -3 <= 5 withMessage: 'should be true: -3 <= 5'.
+    self assertTrue: 1 <= 1 withMessage: 'should be true: 1 <= 1'.
+    self assertTrue: -1 <= -1 withMessage: 'should be true: -1 <= -1'.
+    self assertFalse: 5 <= 1 withMessage: 'should be false: 5 <= 1'.
+    self assertFalse: -1 <= -5 withMessage: 'should be false: -1 <= -5'.
+    self assertFalse: 5 <= -3 withMessage: 'should be false: 5 <= -3'.
+
+- testGreaterThan
+    self assertFalse: 1 > 5 withMessage: 'should be false: 1 > 5'.
+    self assertFalse: -5 > -1 withMessage: 'should be false: -5 > -1'.
+    self assertFalse: -3 > 5 withMessage: 'should be false: -3 > 5'.
+    self assertTrue: 5 > 1 withMessage: 'should be true: 5 > 1'.
+    self assertTrue: -1 > -5 withMessage: 'should be true: -1 > -5'.
+    self assertTrue: 5 > -3 withMessage: 'should be true: 5 > -3'.
+
+- testGreaterThanOrEqual
+    self assertFalse: 1 >= 5 withMessage: 'should be false: 1 >= 5'.
+    self assertFalse: -5 >= -1 withMessage: 'should be false: -5 >= -1'.
+    self assertFalse: -3 >= 5 withMessage: 'should be false: -3 >= 5'.
+    self assertTrue: 1 >= 1 withMessage: 'should be true: 1 >= 1'.
+    self assertTrue: -1 >= -1 withMessage: 'should be true: -1 >= -1'.
+    self assertTrue: 5 >= 1 withMessage: 'should be true: 5 >= 1'.
+    self assertTrue: -1 >= -5 withMessage: 'should be true: -1 >= -5'.
+    self assertTrue: 5 >= -3 withMessage: 'should be true: 5 >= -3'.
+
+- testQuotient
+    self assert: 9 // 4 equals: 2 withMessage: '9 // 4 should be 2'.
+    self assert: -9 // 4 equals: -3 withMessage: '-9 // 4 should be -3'.

--- a/src/test/smalltalk/st/redline/kernel/IntervalTest.st
+++ b/src/test/smalltalk/st/redline/kernel/IntervalTest.st
@@ -1,0 +1,63 @@
+"Redline Smalltalk, Copyright (c) James C. Ladd. All rights reserved. See LICENSE in the root of this distribution."
+
+self import: 'st.redline.test.TestCase'.
+
+TestCase subclass: #IntervalTest.
+
+- test
+    self testSize.
+    self testAt.
+    self testDo.
+    self testCollect.
+
+- testSize
+    | interval |
+    interval := Interval from: 1 to: 5.
+    self assert: interval size equals: 5 withMessage: 'should have size 5'.
+    interval := Interval from: 1 to: 5 by: 2.
+    self assert: interval size equals: 3 withMessage: 'should have size 3'.
+    interval := Interval from: 9 to: 2 by: -3.
+    self assert: interval size equals: 3 withMessage: 'should have size 3'.
+
+- testAt
+    | interval |
+    interval := Interval from: 1 to: 5.
+    self assert: (interval at: 1) equals: 1 withMessage: 'should have 1 at: 1'.
+    self assert: (interval at: 2) equals: 2 withMessage: 'should have 2 at: 2'.
+    self assert: (interval at: 5) equals: 5 withMessage: 'should have 5 at: 5'.
+    interval := Interval from: 1 to: 5 by: 2.
+    self assert: (interval at: 1) equals: 1 withMessage: 'should have 1 at: 1'.
+    self assert: (interval at: 2) equals: 3 withMessage: 'should have 3 at: 2'.
+    self assert: (interval at: 3) equals: 5 withMessage: 'should have 5 at: 3'.
+    interval := Interval from: 9 to: 2 by: -3.
+    self assert: (interval at: 1) equals: 9 withMessage: 'should have 9 at: 1'.
+    self assert: (interval at: 2) equals: 6 withMessage: 'should have 6 at: 2'.
+    self assert: (interval at: 3) equals: 3 withMessage: 'should have 3 at: 3'.
+
+- testDo
+    | interval result |
+    interval := Interval from: 1 to: 5.
+    result := 0.
+    interval do: [ :each | result := result + each. ].
+    self assert: result equals: 15 withMessage: 'should sum to 15'.
+    interval := Interval from: 1 to: 5 by: 2.
+    result := 0.
+    interval do: [ :each | result := result + each. ].
+    self assert: result equals: 9 withMessage: 'should sum to 9'.
+    interval := Interval from: 9 to: 2 by: -3.
+    result := 0.
+    interval do: [ :each | result := result + each. ].
+    self assert: result equals: 18 withMessage: 'should sum to 18'.
+
+- testCollect
+    | interval result |
+    interval := Interval from: 1 to: 5.
+    result := interval collect: [ :each | each * 2 ].
+    self assert: result class equals: Array withMessage: 'should collect into an Array'.
+    self assert: result equals: #(2 4 6 8 10) withMessage: 'should produce Array of double values'.
+    interval := Interval from: 1 to: 5 by: 2.
+    result := interval collect: [ :each | each * each ].
+    self assert: result equals: #(1 9 25) withMessage: 'should produce Array of squared values'.
+    interval := Interval from: 9 to: 2 by: -3.
+    result := interval collect: [ :each | each + 5 ].
+    self assert: result equals: #(14 11 8) withMessage: 'should produce Array of values incremented by 5'.

--- a/src/test/smalltalk/st/redline/kernel/NumberTest.st
+++ b/src/test/smalltalk/st/redline/kernel/NumberTest.st
@@ -1,0 +1,40 @@
+"Redline Smalltalk, Copyright (c) James C. Ladd. All rights reserved. See LICENSE in the root of this distribution."
+
+self import: 'st.redline.test.TestCase'.
+
+TestCase subclass: #NumberTest.
+
+- test
+    self testTo.
+    self testToBy.
+    self testToDo.
+    self testToDoBy.
+
+- testTo
+    | interval |
+    interval := 1 to: 5.
+    self assert: interval class equals: Interval withMessage: 'should create an interval'.
+    self assert: interval size equals: 5 withMessage: 'should have size 5'.
+
+- testToBy
+    | interval |
+    interval := 1 to: 5 by: 3.
+    self assert: interval class equals: Interval withMessage: 'should create an interval'.
+    self assert: interval size equals: 2 withMessage: 'should have size 2'.
+    interval := 9 to: -5 by: -4.
+    self assert: interval size equals: 4 withMessage: 'should have size 4'.
+
+- testToDo
+    | result |
+    result := 0.
+    1 to: 5 do: [ :each | result := result + each. ].
+    self assert: result equals: 15 withMessage: 'should sum range to 15'.
+
+- testToByDo
+    | result |
+    result := 0.
+    -7 to: 5 by: 2 do: [ :each | result := result + each. ].
+    self assert: result equals: 5 withMessage: 'should sum range to 5'.
+    result := 0.
+    18 to: -25 by: -3 do: [ :each | result := result + each. ].
+    self assert: result equals: -45 withMessage: 'should sum range to -45'.

--- a/src/test/smalltalk/st/redline/kernel/SequenceableCollectionTest.st
+++ b/src/test/smalltalk/st/redline/kernel/SequenceableCollectionTest.st
@@ -1,0 +1,57 @@
+"Redline Smalltalk, Copyright (c) James C. Ladd. All rights reserved. See LICENSE in the root of this distribution."
+
+self import: 'st.redline.test.TestCase'.
+
+TestCase subclass: #SequenceableCollectionTest.
+
+- test
+    self testEquals.
+    self testReplaceFromToWithStartingAt.
+    self testCopyReplaceFromToWith.
+    self testConcatenation.
+
+- testEquals
+    | first second |
+    first := #(1 2 3).
+    second := #(1 2 3).
+    self assertTrue: first = second withMessage: 'should be equal if elements are equal'.
+    first := #(1 2 3).
+    second := #(4 5 6).
+    self assertFalse: first = second withMessage: 'should be not equal if elements are not equal'.
+    first := #(1 2 3).
+    second := #(1 2).
+    self assertFalse: first = second withMessage: 'should be not equal if not the same length'.
+
+- testReplaceFromToWithStartingAt
+    | collection replacement result |
+    collection := #(1 2 3 4 5 6).
+    replacement := #(7 8 9).
+    result := collection replaceFrom: 2 to: 4 with: replacement startingAt: 1.
+    self assert: result equals: #(1 7 8 9 5 6) withMessage: 'should replace subsequence with all of replacement'.
+    collection := #(1 2 3 4 5 6).
+    replacement := #(7 8 9).
+    result := collection replaceFrom: 5 to: 6 with: replacement startingAt: 1.
+    self assert: result equals: #(1 2 3 4 7 8) withMessage: 'should replace subsequence as far as required'.
+
+- testCopyReplaceFromToWith
+    | collection replacement result |
+    collection := #(1 2 3 4 5 6).
+    replacement := #(7 8 9).
+    result := collection copyReplaceFrom: 2 to: 4 with: replacement.
+    self assert: result equals: #(1 7 8 9 5 6) withMessage: 'should replace subsequence'.
+    self assert: collection equals: #(1 2 3 4 5 6) withMessage: 'should preserve receiver'.
+    result := collection copyReplaceFrom: 1 to: 0 with: replacement.
+    self assert: result equals: #(7 8 9 1 2 3 4 5 6) withMessage: 'should insert at beginning'.
+    self assert: collection equals: #(1 2 3 4 5 6) withMessage: 'should preserve receiver'.
+    result := collection copyReplaceFrom: 7 to: 6 with: replacement.
+    self assert: result equals: #(1 2 3 4 5 6 7 8 9) withMessage: 'should append at end'.
+    self assert: collection equals: #(1 2 3 4 5 6) withMessage: 'should preserve receiver'.
+
+- testConcatenation
+    | first second result |
+    first := #(1 2 3).
+    second := #(4 5 6).
+    result := #(1 2 3 4 5 6).
+    self assert: first , second equals: result withMessage: 'should concatenate Arrays'.
+    self assert: first equals: #(1 2 3) withMessage: 'should preserve receiver'.
+    self assert: second equals: #(4 5 6) withMessage: 'should preserve argument'.

--- a/src/test/smalltalk/st/redline/kernel/StringTest.st
+++ b/src/test/smalltalk/st/redline/kernel/StringTest.st
@@ -1,0 +1,33 @@
+"Redline Smalltalk, Copyright (c) James C. Ladd. All rights reserved. See LICENSE in the root of this distribution."
+
+self import: 'st.redline.test.TestCase'.
+
+TestCase subclass: #StringTest.
+
+- test
+    self testSize.
+    self testAt.
+    self testReplaceFromToWithStartingAt.
+    self testConcatenation.
+
+- testSize
+    self assert: 'hello' size equals: 5 withMessage: 'should report length of string'.
+    self assert: '' size equals: 0 withMessage: 'should report length of string'.
+
+- testAt
+    | aString |
+    aString := 'Hello, World!'.
+    self assert: (aString at: 3) equals: $l withMessage: 'should index a Character from a String'.
+    self assert: (aString at: 6) equals: $, withMessage: 'should index a Character from a String'.
+
+- testReplaceFromToWithStartingAt
+    | aString |
+    aString := 'Hello, there!'.
+    aString replaceFrom: 8 to: 12 with: 'World' startingAt: 1.
+    self assert: aString equals: 'Hello, World!' withMessage: 'should replace a subsequence'.
+
+- testConcatenation
+    | hello world |
+    hello := 'Hello, '.
+    world := 'World!'.
+    self assert: hello , world equals: 'Hello, World!' withMessage: 'should be able to concatenate strings'.

--- a/src/test/smalltalk/st/redline/kernel/TestSuite.st
+++ b/src/test/smalltalk/st/redline/kernel/TestSuite.st
@@ -16,6 +16,14 @@ Object subclass: #TestSuite.
     ObjectTest new test.
     self show: 'Running CollectionTests'.
     CollectionTest new test.
+    self show: 'Running StringTests'.
+    StringTest new test.
+    self show: 'Running IntegerTests'.
+    IntegerTest new test.
+    self show: 'Running SequenceableCollectionTests'.
+    SequenceableCollectionTest new test.
+    self show: 'Running IntervalTests'.
+    IntervalTest new test.
 
 - show: message
     Transcript show: message; cr.

--- a/src/test/smalltalk/st/redline/kernel/TestSuite.st
+++ b/src/test/smalltalk/st/redline/kernel/TestSuite.st
@@ -14,6 +14,8 @@ Object subclass: #TestSuite.
     FalseTest new test.
     self show: 'Running ObjectTests'.
     ObjectTest new test.
+    self show: 'Running CollectionTests'.
+    CollectionTest new test.
 
 - show: message
     Transcript show: message; cr.


### PR DESCRIPTION
    To achieve this, the following have been implemented according to the
    Blue Book.  Tests for new functionality have been added.
    
    PrimSubclass
        instance variables now supported (not the best way, I expect, but it
    works)
    ProtoClass
        instance variable support
    ProtoObject
        I have implemented the SmallInteger primitives for class Integer as
    we don't currently have SmallInteger and it doesn't seem valuable at the
    moment.
        p1 Integer +
        p2 Integer -
        p3 Integer <
        p4 Integer >
        p5 Integer <=
        p6 Integer >=
        p7 Integer =
        p9 Integer *
        p10 Integer / (Note: Need to implement Fraction class!)
        p32 Integer //
        p62 Object size (fixed incorrect value for collections), String size
        p63 String at:
        p70 new (instance variables supported)
        p71 new:
        p105 String replaceFrom:to:with:startingAt:
        p110 Object == (added Character =)
        p138 Block whileTrue:
    
    Smalltalk code:
    Behaviour
        new:
        basicNew:
    Character
        =
    Integer
        + - * / (need to produce Fraction when they are implemented) // = <
    <= > >=
    Interval
        +from:to
        +from:to:by:
        species
        size
        at:
        do:
        collect:
        setFrom:to:by:
    Number
        to:
        to:by:
        to:do:
        to:by:do:
    Object
        species
        errorSubscriptBounds:
    SequenceableCollection
        = (Though there is an issue with block returns which needs
    addressing to fully complete this.)
        replaceFrom:to:with:startingAt:
        ,
        copyReplaceFrom:to:with:
    String
        replaceFrom:to:with:startingAt:
        at:

Signed-off-by: Mark Bush redline@bushnet.org